### PR TITLE
Agenda: Add detailed agenda

### DIFF
--- a/content/posts/2022-02-22-opi-event.md
+++ b/content/posts/2022-02-22-opi-event.md
@@ -16,13 +16,105 @@ The event schedule and speaker list is provided below.
 OPI Event - Day 1
 Time: Mar 15, 2022 08:00 AM Pacific Time
 [Meeting Link](https://intel.zoom.us/j/95556827603?pwd=alJINUltbUlIVklzLzBNTXRrRHI4dz09)
-<a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MTFlanZtbW4zbXY0M2EyZXBqOTc1NXRncTUga29hdDliOTEyYWhqazBuZmVqaTUydWZhNW9AZw&amp;tmsrc=koat9b912ahjk0nfeji52ufa5o%40group.calendar.google.com"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
 
 OPI Event - Day 2
 Time: Mar 16, 2022 08:00 AM Pacific Time
 [Meeting Link](https://intel.zoom.us/j/91369118581?pwd=UmdJKzlSd2Z6czNtcWRZYTBsenNVUT09)
-<a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&amp;tmeid=MzVlZDVtbnBmaTJhYnBxZjg2bzFrbjh1Y28ga29hdDliOTEyYWhqazBuZmVqaTUydWZhNW9AZw&amp;tmsrc=koat9b912ahjk0nfeji52ufa5o%40group.calendar.google.com"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
 
 ![Day 1 Schedule](/opi-event-slide3.jpeg)
 ![Day 2 Schedule](/opi-event-slide4.jpeg)
 ![Break Session Descriptions](/opi-event-slide5.jpeg)
+
+## Detailed Agenda
+
+{{< rawhtml >}}
+<style>
+table {
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: collapse;
+  border: 3px solid orange;
+}
+
+thead th:nth-child(1) {
+  width: 15%;
+}
+
+thead th:nth-child(2) {
+  width: 20%;
+}
+
+thead th:nth-child(3) {
+  width: 35%;
+}
+
+thead th:nth-child(4) {
+  width: 30%;
+}
+
+th, td {
+  padding: 20px;
+}
+html {
+  font-family: 'helvetica neue', helvetica, arial, sans-serif;
+}
+
+thead th, tfoot th {
+  font-family: 'Rock Salt', cursive;
+  font-size: 0.575em;
+}
+
+th {
+  letter-spacing: 2px;
+}
+
+td {
+  letter-spacing: 1px;
+}
+
+tbody td {
+  text-align: center;
+  font-size: 0.575em;
+}
+
+tfoot th {
+  text-align: right;
+}
+
+thead {
+  background-color: #333;
+  color: white;
+}
+
+tbody tr:nth-child(odd) {
+  background-color: #fff;
+}
+
+tbody tr:nth-child(even) {
+  background-color: #eee;
+}
+</style>
+{{< /rawhtml >}}
+
+{{< table "table table-striped table-bordered" >}}
+| Day | Speaker | Title | Abstract |
+|-----|---------|-------|----------|
+| 1   | Google | Coming soon | Coming soon |
+| 1   | Dell | Coming soon | Coming soon |
+| 1   | Meta | Coming soon | Coming soon |
+| 1   | Lightbits | Coming soon | Coming soon |
+| 1   | Debo Dutta, Nutanix | MLOps Meets Programmable Infrastructure | Coming soon |
+| 1   | Ian Wells, Cisco | How Programmable Infrastructure Can Enable Better Edge Computing | Edge Computing has become a hot topic recently. This talk will level set on what Edge Computing is, and then present a world where programmable infrastructure can make edge computing better. The talk will provide the programmable infrastructure community an oppurtunity to build software for this use case. |
+| 1   | Tim Michels, F5 | DPU Disruption of Today’s Infrastructure Paradigm | Explore with F5 the exciting potential for DPU technology to bring disruptive change to the infrastructure and topology of the data center, private cloud, or edge deployments of the future.  Learn to define what a DPU is, how it can be used to separate infrastructure services from application workloads, and why this is so important.  Hear the call to action to drive this technology into the future by creating an open community engaged in the definition of frameworks and APIs targeting vendor-agnostic interoperability. |
+| 1   | VMware | Coming soon | Coming soon |
+| 1   | Kyle Mestery (Intel), Kris Murphy (Red Hat), Paul Pindell (F5) | Next Steps in Community Building/Evolution | We will talk about where OPI goes next in terms of it's community governance. |
+| 2   | IBM | Coming soon | Coming soon |
+| 2   | Ericson | Coming soon | Coming soon |
+| 2   | Tom Nadeau, Spirent | The Importance of Testing In Your Open Source Infrastructure Project | Join Tom as he discusses why testing is important in your Open Source project, and how it can better enable programmable infrastructure. |
+| 2   | Keysight | Coming soon | Coming soon |
+| 2   | Red Hat | Coming soon | Coming soon |
+| 2   | Breakout Session 1: Marvell and Intel | Target Abstraction Composition | Coming soon |
+| 2   | Breakout Session 2: F5 | Application Abstraction Composition | Coming soon |
+| 2   | Breakout Session 3: Dell and Red Hat | Lifecycle/APIs/Provisioning Management across DPU/IPU/Switches | Coming soon |
+| 2   | Kyle Mestery (Intel), Kris Murphy (Red Hat), Paul Pindell (F5) | Closing thoughts | Why is standardization important for the end-users, the 3rd party vendors integrating with these devices, and ultimately for the vendors of these devices. We will touch on this topic and also have a call to action for the community to join with us in this endeavor. |
+{{< /table >}}

--- a/layouts/shortcodes/rawhtml.html
+++ b/layouts/shortcodes/rawhtml.html
@@ -1,0 +1,2 @@
+<!-- raw html -->
+{{.Inner}}

--- a/layouts/shortcodes/table.html
+++ b/layouts/shortcodes/table.html
@@ -1,0 +1,6 @@
+{{ $htmlTable := .Inner | markdownify }}
+{{ $class := .Get 0 }}
+{{ $old := "<table>" }}
+{{ $new := printf "<table class=\"%s\">" $class }}
+{{ $htmlTable := replace $htmlTable $old $new }}
+{{ $htmlTable | safeHTML }}


### PR DESCRIPTION
This adds table support in a really awful way, but I'm not a CSS expert,
I only play one when supporting Hugo websites. It seems as if the
standard Hugo shortcode way [1] of supporting tables doesn't work with
the Tachyon CSS engine [2] which our Ananke theme [3] uses.

To make this work, I added a rawhtml shortcode which allows me to update
the CSS stylesheet right before the table to make it display properly.

[1] https://willschenk.com/articles/2020/styling_tables_with_hugo/
[2] https://tachyons.io
[3] https://github.com/theNewDynamic/gohugo-theme-ananke

Signed-off-by: Kyle Mestery <mestery@mestery.com>